### PR TITLE
Include time in the default seed (fixes #2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # dqrng 0.0.3.9000
 
 * Fix critical bug w.r.t. setting seeds
+* Use time in addition to `std::random_device` as source of the default seed, since
+  `std::random_device` is deterministic with MinGW (c.f. #2)
 
 # dqrng 0.0.3
 

--- a/inst/include/dqrng_generator.h
+++ b/inst/include/dqrng_generator.h
@@ -58,14 +58,20 @@ public:
 
 template<typename RNG = default_64bit_generator>
 typename std::enable_if<!std::is_base_of<random_64bit_generator, RNG>::value, rng64_t>::type
-generator (uint64_t seed = std::random_device{}()) {
+generator (uint64_t seed) {
   return std::make_shared<random_64bit_wrapper<RNG>>(seed);
 }
 
 template<typename RNG = default_64bit_generator>
 typename std::enable_if<std::is_base_of<random_64bit_generator, RNG>::value, rng64_t>::type
-generator (uint64_t seed = std::random_device{}()) {
+generator (uint64_t seed) {
   return std::make_shared<RNG>(seed);
+}
+
+template<typename RNG = default_64bit_generator>
+rng64_t generator() {
+  uint64_t seed = std::random_device{}();
+  return generator<RNG>(seed);
 }
 } // namespace dqrng
 

--- a/inst/include/dqrng_generator.h
+++ b/inst/include/dqrng_generator.h
@@ -19,6 +19,7 @@
 #define DQRNG_GENERATOR_H 1
 
 #include <cstdint>
+#include <chrono>
 #include <memory>
 #include <random>
 #include <type_traits>
@@ -71,6 +72,8 @@ generator (uint64_t seed) {
 template<typename RNG = default_64bit_generator>
 rng64_t generator() {
   uint64_t seed = std::random_device{}();
+  uint64_t time = std::chrono::system_clock::now().time_since_epoch().count();
+  seed = seed | time;
   return generator<RNG>(seed);
 }
 } // namespace dqrng


### PR DESCRIPTION
With MinGW the std::random_device is deterministic. The timestamp is
included in the default seed to circumvent this.