### PR TITLE
Use R_unif_index() instead of unif_rand() and move RNGScope

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
 # dqrng (unreleased)
 
 * Add R side support for selecting multiple streams for parallel usage.
-* Implement `long_jump()` for Xo(ro)shiro as alternative to `jump()` providing fewer streams with longer period.
+* Implement `long_jump()` for Xo(ro)shiro as alternative to `jump()`
+  providing fewer streams with longer period.
 * Handle R's RNG scope properly during initialisation.
-* New functions `dqsample` and `dqsample.int` using an unbiased sampling algorithm
+* New functions `dqsample` and `dqsample.int` using an unbiased sampling
+  algorithm.
+* Use `R_unif_index()` instead of `unif_rand()` to retrieve random data
+  from R's RNG in `generateSeedVectors()`.
 
 # dqrng 0.1.1
 
@@ -15,7 +19,7 @@
 ## Breaking changes
 
 * An integer vector instead of a single `int` is used for seeding (Aaron Lun in [#10](https://github.com/daqana/dqrng/pull/10))
-  * Single integer seeds lead to a different RNG state than before. 
+  * Single integer seeds lead to a different RNG state than before.
   * `dqrng::dqset_seed()` expects a `Rcpp::IntegerVector` instead of an `int`
 * Support for Mersenne-Twister has been removed, Xoroshiro128+ is now the default.
 

--- a/inst/include/R_randgen.h
+++ b/inst/include/R_randgen.h
@@ -6,12 +6,14 @@
 namespace dqrng {
 
 /* Create a uint32_t or int seed using R's PRNGs.
- * The uint32_t seed is more convnient from use within C++,
+ * The uint32_t seed is more convenient from use within C++,
  * the int seed is more convenient if it needs to be passed back to R.
+ * Since R's PRNG is used, calling one of these functions has to be shielded
+ * with calls to GetRNGState and PutRNGState, e.g. by using Rcpp::RNGScope.
+ * This is done automatically when using the Rcpp::export attribute.
  */
 
 inline uint32_t R_random_u32 () {
-    Rcpp::RNGScope rngScope;
     constexpr double upper_limit=4294967296;
     double val = R_unif_index(upper_limit);
     if (val >= upper_limit) { val=0; } // Absolutely avoid overflow.

--- a/inst/include/R_randgen.h
+++ b/inst/include/R_randgen.h
@@ -5,14 +5,15 @@
 
 namespace dqrng {
 
-/* Create a uint32_t or int seed using R's PRNGs. 
+/* Create a uint32_t or int seed using R's PRNGs.
  * The uint32_t seed is more convnient from use within C++,
  * the int seed is more convenient if it needs to be passed back to R.
  */
 
 inline uint32_t R_random_u32 () {
+    Rcpp::RNGScope rngScope;
     constexpr double upper_limit=4294967296;
-    double val=R::unif_rand() * upper_limit;
+    double val = R_unif_index(upper_limit);
     if (val >= upper_limit) { val=0; } // Absolutely avoid overflow.
     return static_cast<uint32_t>(val);
 }
@@ -20,10 +21,10 @@ inline uint32_t R_random_u32 () {
 inline int R_random_int () {
     const uint32_t sampled=R_random_u32();
     constexpr uint32_t max_int=2147483647; // See .Machine$integer.max.
-    if (sampled <= max_int) { 
+    if (sampled <= max_int) {
         return static_cast<int>(sampled);
     }
-    
+
     // Effectively reverse of the int->uint32_t cast.
     constexpr uint32_t max_uint=-1;
     return -static_cast<int>(max_uint - sampled) - 1;

--- a/src/dqrng.cpp
+++ b/src/dqrng.cpp
@@ -27,6 +27,7 @@
 
 namespace {
 dqrng::rng64_t init() {
+  Rcpp::RNGScope rngScope;
   Rcpp::IntegerVector seed(2, dqrng::R_random_int);
   return dqrng::generator(dqrng::convert_seed<uint64_t>(seed));
 }

--- a/src/dqrng.cpp
+++ b/src/dqrng.cpp
@@ -27,7 +27,6 @@
 
 namespace {
 dqrng::rng64_t init() {
-  Rcpp::RNGScope rngScope;
   Rcpp::IntegerVector seed(2, dqrng::R_random_int);
   return dqrng::generator(dqrng::convert_seed<uint64_t>(seed));
 }


### PR DESCRIPTION
The change from `unif_rand()` to `R_unif_index()` changes the amount of RNG draws even before R version 3.6. Loading dqrng, which needs 64 bits for seeding, used to advance R's RNG by two steps:

```
> set.seed(42)
> runif(10)
 [1] 0.9148060 0.9370754 0.2861395 0.8304476 0.6417455 0.5190959 0.7365883
 [8] 0.1346666 0.6569923 0.7050648
> set.seed(42)
> library(dqrng)
> runif(10)
 [1] 0.2861395 0.8304476 0.6417455 0.5190959 0.7365883 0.1346666 0.6569923
 [8] 0.7050648 0.4577418 0.7191123
```

With this change it advances R's RNG by four steps:

```
> set.seed(42)
> runif(10)
 [1] 0.9148060 0.9370754 0.2861395 0.8304476 0.6417455 0.5190959 0.7365883
 [8] 0.1346666 0.6569923 0.7050648
> set.seed(42)
> library(dqrng)
> runif(10)
 [1] 0.6417455 0.5190959 0.7365883 0.1346666 0.6569923 0.7050648 0.4577418
 [8] 0.7191123 0.9346722 0.2554288
```

Overall this will decrease the speed of `generateseedVectors` *and* produce different results.
@LTLA Would this be a problem for you?