### PR TITLE
Explicitly include required std headers for xoshiro.

### DIFF
--- a/inst/include/dqrng_generator.h
+++ b/inst/include/dqrng_generator.h
@@ -151,27 +151,27 @@ public:
 };
 
 template<>
-void random_64bit_wrapper<::dqrng::xoroshiro128plus>::seed(result_type seed, result_type stream) {
+inline void random_64bit_wrapper<::dqrng::xoroshiro128plus>::seed(result_type seed, result_type stream) {
     gen.seed(seed);
     gen.jump(stream);
     cache = false;
 }
 
 template<>
-void random_64bit_wrapper<::dqrng::xoshiro256plus>::seed(result_type seed, result_type stream) {
+inline void random_64bit_wrapper<::dqrng::xoshiro256plus>::seed(result_type seed, result_type stream) {
     gen.seed(seed);
     gen.long_jump(stream);
     cache = false;
 }
 
 template<>
-void random_64bit_wrapper<pcg64>::seed(result_type seed, result_type stream) {
+inline void random_64bit_wrapper<pcg64>::seed(result_type seed, result_type stream) {
     gen.seed(seed, stream);
     cache = false;
 }
 
 template<>
-void random_64bit_wrapper<sitmo::threefry_20_64>::seed(result_type seed, result_type stream) {
+inline void random_64bit_wrapper<sitmo::threefry_20_64>::seed(result_type seed, result_type stream) {
     gen.seed(seed);
     gen.set_counter(0, 0, 0, stream);
     cache = false;

--- a/inst/include/xoshiro.h
+++ b/inst/include/xoshiro.h
@@ -13,6 +13,9 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
+#include <algorithm>
+#include <type_traits>
 
 namespace dqrng {
 template<size_t N, int_fast8_t A, int_fast8_t B, int_fast8_t C>


### PR DESCRIPTION
Inline template specializations for correct linking, fixes #28.