### PR TITLE
fix: testhat finds dqrng header

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^revdep$
 ^\.github$
 ^CRAN-SUBMISSION$
+^include$

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ inst/doc
 vignettes/*.R
 vignettes/*.html
 /revdep
-/include
 /external/tmp

--- a/include
+++ b/include
@@ -1,0 +1,1 @@
+inst/include


### PR DESCRIPTION
## Summary

Symlink `inst/include` to `include` to fix testthat issues with package's own headers; see https://github.com/r-lib/devtools/issues/1617.

---
Close #60