### PR TITLE
Add missing inline attributes to avoid linker issues.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * The default RNG has changed from Xoroshiro128+ to Xoroshiro128++. The older generators Xoroshiro128+ and Xoshiro256+ are still available but should only be used for backward compatibility or for generating floating point numbers, i.e. not sampling etc.  ([#57](https://github.com/daqana/dqrng/pull/57) fixing [#56](https://github.com/daqana/dqrng/issues/56))
 * The `dqrng::rng64_t` type has been changed to use `Rcpp::XPtr` instead of `std::shared_ptr` and the functions from `dqrng_sample.h` now expect a reference to `dqrng::random_64bit_generator` instead of `dqrng::rng64_t` ([#70](https://github.com/daqana/dqrng/pull/70) fixing [#63](https://github.com/daqana/dqrng/issues/63))
+* Add missing inline attributes and limit the included Rcpp headers in `dqrng_types.h` ([#75](https://github.com/daqana/dqrng/pull/75) together with Paul Liétar)
 
 ## Other changes
 

--- a/inst/include/dqrng_types.h
+++ b/inst/include/dqrng_types.h
@@ -22,7 +22,7 @@
 
 #include <mystdint.h>
 #include <stdexcept>
-#include <Rcpp/Lightest>
+#include <Rcpp/XPtr.h>
 
 namespace dqrng {
 

--- a/inst/include/xoshiro.h
+++ b/inst/include/xoshiro.h
@@ -104,7 +104,7 @@ public:
 };
 
 template<>
-void xoshiro<2>::do_jump(std::array<result_type, 2> JUMP) {
+inline void xoshiro<2>::do_jump(std::array<result_type, 2> JUMP) {
     uint64_t s0 = 0;
     uint64_t s1 = 0;
     for(unsigned int i = 0; i < sizeof JUMP / sizeof JUMP.begin(); i++)
@@ -121,7 +121,7 @@ void xoshiro<2>::do_jump(std::array<result_type, 2> JUMP) {
 }
 
 template<>
-void xoshiro<4>::do_jump(std::array<result_type, 4> JUMP) {
+inline void xoshiro<4>::do_jump(std::array<result_type, 4> JUMP) {
     uint64_t s0 = 0;
     uint64_t s1 = 0;
     uint64_t s2 = 0;


### PR DESCRIPTION
The `xoshiro<2>::do_jump` specializations need some `inline` attribute, otherwise including dqrng from multiple compilation units causes linker errors due to symbols being defined multiple times.

~~While compiling against the latest pre-release, I hit some build errors which this should fix.~~

~~Firstly, the `dqrng_types.h` file was including `Rcpp/Lightest`, which should provide a slimmer interface to Rcpp. Unfortunately, the decision to include that file is "infectious" and impacts any compilation unit which includes dqrng. This is because including `Rcpp/Lightest` ends up defining `Rcpp_hpp`, and subsequent includes of `Rcpp.h` do nothing. My end applipcation was unable to use Rcpp's extended API because of this.~~